### PR TITLE
update optimist version to remove vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "linux"
   ],
   "dependencies": {
-    "optimist": "~0.6.1",
+    "optimist": "^0.5.2",
     "mu2": "~0.5.20"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
``` bash
$ npm install

added 96 packages, and audited 97 packages in 6s

29 packages are looking for funding
  run `npm fund` for details

2 critical severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
(base) hgsi-stern-prod-eks-eks-cluster:~/git/node-linux
$ npm audit fix

up to date, audited 97 packages in 1s

29 packages are looking for funding
  run `npm fund` for details

# npm audit report

minimist  <=0.2.3
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
fix available via `npm audit fix --force`
Will install optimist@0.5.2, which is a breaking change
node_modules/minimist
  optimist  >=0.6.0
  Depends on vulnerable versions of minimist
  node_modules/optimist

2 critical severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
(base) hgsi-stern-prod-eks-eks-cluster:~/git/node-linux
$ npm audit fix --force
npm warn using --force Recommended protections disabled.
npm warn audit Updating optimist to 0.5.2, which is a SemVer major change.

removed 1 package, changed 1 package, and audited 96 packages in 1s

29 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```